### PR TITLE
Add version field to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "paho-client",
+	"version": "1.0.1",
 	"description": "Pre reqs for the Paho JS client",
 	"dependencies": {
 		"websocket": "1.x.x",


### PR DESCRIPTION
Npm install fails without a version field (it is a required element in package.json). This PR fixes this.